### PR TITLE
Upgrade Mockito to support java13+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <kafka.version>3.3.1</kafka.version>
         <aws.sdk.version>1.12.389</aws.sdk.version>
         <junit.jupiter.version>5.7.0</junit.jupiter.version>
-        <mockito.version>3.6.0</mockito.version>
+        <mockito.version>4.0.0</mockito.version>
         <assertj.version>3.17.2</assertj.version>
         <surefire-plugin.version>3.0.0-M8</surefire-plugin.version>
     </properties>


### PR DESCRIPTION
*Issue #, if available:* Closes #4

*Description of changes:*
Upgrades Mockito to 4.0.0. Before this commit `nvm clean install` fails due to mockito-3.6.0 dependency byte-buddy doesn't support Java13+

*Testing:*
ran `nvm clean install` successfully with Java 8, 17, 19

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
